### PR TITLE
Don't count surplus if recipe is not a producer, closes #990

### DIFF
--- a/src/app/utilities/simplex.utility.ts
+++ b/src/app/utilities/simplex.utility.ts
@@ -956,6 +956,7 @@ export class SimplexUtility {
       output = output.add(amount);
 
       if (
+        recipe.produces(itemId) &&
         state.data.itemRecipeId[itemId] &&
         state.data.itemRecipeId[itemId] !== recipe.id
       ) {

--- a/src/app/utilities/simplex.utility.ts
+++ b/src/app/utilities/simplex.utility.ts
@@ -955,11 +955,7 @@ export class SimplexUtility {
         .div(recipe.time);
       output = output.add(amount);
 
-      if (
-        recipe.produces(itemId) &&
-        state.data.itemRecipeId[itemId] &&
-        state.data.itemRecipeId[itemId] !== recipe.id
-      ) {
+      if (!this.includeRecipeOutput(itemId, recipe, state)) {
         // This recipe produces the item but does not match the default recipe
         // Include this amount as part of the surplus
         surplus = surplus.add(amount);


### PR DESCRIPTION
I didn't change any test cases since it still passes the tests. Might need a new test case for this specific situation.