### PR TITLE
build: Add Mac script support and fit latest version of factorio's prototype-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postfactorio-api": "prettier --write \"scripts/factorio.models.ts\"",
     "factorio-prep": "ts-node -r tsconfig-paths/register scripts/factorio-prep.ts",
     "factorio-dump": "scripts\\factorio-dump.bat",
+    "factorio-dump:mac": "scripts/factorio-dump.sh",
     "factorio-build": "ts-node -r tsconfig-paths/register scripts/factorio-build.ts",
     "factorio-update": "ts-node -r tsconfig-paths/register scripts/factorio-update.ts",
     "calculate-color": "ts-node -r tsconfig-paths/register scripts/calculate-color.ts",

--- a/scripts/factorio-api.ts
+++ b/scripts/factorio-api.ts
@@ -75,6 +75,8 @@ function parseType(type: M.DataType, structName?: string): string {
         return 'number';
       case 'string':
         return 'string';
+      case 'DataExtendMethod':
+        return '() => void';
       default:
         return type;
     }

--- a/scripts/factorio-build.ts
+++ b/scripts/factorio-build.ts
@@ -64,7 +64,9 @@ if (!mod) {
 }
 
 // Set up paths
-const appDataPath = process.env['AppData'];
+const appDataPath =
+  process.env['AppData'] ||
+  `${process.env['HOME']}/Library/Application Support`;
 const factorioPath = `${appDataPath}/Factorio`;
 const modsPath = `${factorioPath}/mods`;
 const scriptOutputPath = `${factorioPath}/script-output`;

--- a/scripts/factorio-dump.sh
+++ b/scripts/factorio-dump.sh
@@ -1,0 +1,5 @@
+cd ~/Library/Application\ Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS
+
+./factorio --dump-data
+./factorio --dump-prototype-locale
+/Applications/Steam.app/Contents/MacOS/steam_osx -applaunch 427520 --dump-icon-sprites

--- a/scripts/helpers/file.helpers.ts
+++ b/scripts/helpers/file.helpers.ts
@@ -7,7 +7,10 @@ export function getJsonData<T>(file: string): T {
   return JSON.parse(str) as T;
 }
 
-const scriptOutputPath = `${process.env['AppData']}/Factorio/script-output`;
+const appDataPath =
+  process.env['AppData'] ||
+  `${process.env['HOME']}/Library/Application Support`;
+const scriptOutputPath = `${appDataPath}/Factorio/script-output`;
 export function getLocale(file: string): D.Locale {
   const path = `${scriptOutputPath}/${file}`;
   return getJsonData<D.Locale>(path);


### PR DESCRIPTION
1. now you can run factorio-dump:mac to get factorio's data raw;
2. fit a new built-in type DataExtendMethod for latest 1.1.107

I didn't commit latest factorio.models.ts, maybe you can run and build a new version of this application.