### PR TITLE
fix: Fix broken import for scripts

### DIFF
--- a/scripts/helpers/data.helpers.ts
+++ b/scripts/helpers/data.helpers.ts
@@ -7,7 +7,7 @@ import {
 } from 'scripts/factorio.models';
 
 import { ModHash } from '~/models/data/mod-hash';
-import { Entities } from '~/models/entities';
+import { Entities } from '~/models/utils';
 
 import {
   allEffects,


### PR DESCRIPTION
162ad6d completely removed `src/app/models/entities.ts` as part of refactoring. The definition for `Entities` moved to `src/app/models/utils.ts`. However, `scripts/helpers/data.helpers.ts` still referenced the original file. This didn't break the build or any deployment of the main site, but attempting to run import scripts like `factorio-build` to update a local instance with custom mod configurations would fail:

> TSError: ⨯ Unable to compile TypeScript:
> scripts/helpers/data.helpers.ts:10:26 - error TS2307: Cannot find module '~/models/entities' or its corresponding type declarations.
>
> 10 import { Entities } from '~/models/entities';

This updates `scripts/helpers/data.helpers.ts` to reference the new definition location.