### PR TITLE
fix: Update Factorio researched technologies console script to 2.0

### DIFF
--- a/src/app/components/tech-picker/tech-picker.component.ts
+++ b/src/app/components/tech-picker/tech-picker.component.ts
@@ -149,7 +149,7 @@ for _, tech in pairs(game.player.force.technologies) do
         list[#list + 1] = tech.name
     end
 end
-game.write_file("techs.txt", table.concat(list, ","))
+helpers.write_file("techs.txt", table.concat(list, ","))
 `;
     void window.navigator.clipboard.writeText(script);
     this.translateSvc


### PR DESCRIPTION
In Factorio 2.0, `write_file` was moved to `LuaHelpers` accessible via `helpers`.

This does make the script incompatible with Factorio 1.1, but supporting both is kind of annoying. Feel free to close if you'd rather keep the script compatible with Factorio 1.1.