### PR TITLE
fix: Increase productivity dialog size

### DIFF
--- a/src/app/components/recipe-productivity/recipe-productivity.component.html
+++ b/src/app/components/recipe-productivity/recipe-productivity.component.html
@@ -6,7 +6,7 @@
   [draggable]="false"
   [resizable]="false"
   [focusOnShow]="false"
-  [style]="{ width: '600px', maxHeight: '500px' }"
+  [style]="{ width: '600px' }"
   [breakpoints]="{ '600px': '100vw' }"
   [header]="'settings.recipeProductivity' | translate"
   (onHide)="save()"


### PR DESCRIPTION
Having to enter the research boni is a bit annoying with the small dialog box. Without the `max-height` it just adapts to the screen size and will not increase larger than needed so it always looks fine without. The dialog was introduced with #1587, so @dcbroad3 might have additional thoughts on why the `max-height` was set in the first place? (Maybe I am overlooking something where it is useful?)

I considered removing the `width` too as the window adapts automatically to the content without it. For me, it gets a bit smaller as the research names are shorter than there is width available currently. I tested with longer names which also look fine either way, so I don't have a real preference for the width. Changing it probably also requires adapting the breakpoints, so I guess keeping it is the easiest solution?

`maxHeight` is also defined in `src/app/components/settings/settings.component.html` but I don't know which dialog box that is. Maybe the same change would be useful there too?