### PR TITLE
fix: add prod bonus from research to quality recipes, closes #1635

### DIFF
--- a/src/app/store/settings.service.ts
+++ b/src/app/store/settings.service.ts
@@ -470,9 +470,6 @@ export class SettingsService extends Store<SettingsState> {
     // Generate temporary object arrays
     const items = itemIds.map((i) => parseItem(itemData[i]));
     const recipes = recipeIds.map((r) => parseRecipe(recipeData[r]));
-    const canProdUpgradeRecipeIds = recipes
-      .filter((r) => r.flags.has('canProdUpgrade'))
-      .map((r) => r.id);
 
     // Calculate missing implicit recipe icons
     // For recipes with no icon, use icon of first output item
@@ -614,6 +611,9 @@ export class SettingsService extends Store<SettingsState> {
         }
       });
     }
+    const canProdUpgradeRecipeIds = recipes
+      .filter((r) => r.flags.has('canProdUpgrade'))
+      .map((r) => r.id);
 
     // Filter for item types
     const beaconIds = items


### PR DESCRIPTION
By generating the list `canProdUpgradeRecipeIds` after the quality recipes are generated and not before, I can now also set the productivity bonuses for the quality variants of the recipes with researchable prod bonus. This fixes #1635.

However it also introduces a new recipe prod bonus setting for each quality variant of the base recipe (now 86 settings vs 18 now and only 8 researches). But this would be resolved when fixing #1643, and for me it works great even in the current state (finally I can calculate LDS and blue circuit recycling loops).