### PR TITLE
fix: Handle infinite techs in tech picker console script

### DIFF
--- a/src/app/components/tech-picker/tech-picker.component.ts
+++ b/src/app/components/tech-picker/tech-picker.component.ts
@@ -145,7 +145,7 @@ export class TechPickerComponent extends DialogComponent {
   copyScriptToClipboard(): void {
     const script = `/c local list = {}
 for _, tech in pairs(game.player.force.technologies) do
-    if tech.researched then
+    if tech.researched or tech.level > tech.prototype.level then
         list[#list + 1] = tech.name
     end
 end


### PR DESCRIPTION
`tech.researched` is always false for infinite technologies, since there's always another level of research possible. `tech.level` is the next available level, while `tech.prototype.level` is the first level of the tech. If `tech.level > tech.prototype.level`, then the first infinite level has been researched.