### PR TITLE
fix: Satisfactory overclock affecting belt throughput

### DIFF
--- a/src/app/store/settings.service.ts
+++ b/src/app/store/settings.service.ts
@@ -967,7 +967,7 @@ export class SettingsService extends Store<SettingsState> {
     return spread(state as Settings, {
       beltId,
       defaultBeltId,
-      stack: coalesce(state.overclock, defaults?.beltStack),
+      stack: coalesce(state.stack, defaults?.beltStack),
       pipeId,
       defaultPipeId,
       cargoWagonId,


### PR DESCRIPTION
Example: https://factoriolab.github.io/sfy/list?o=iron-plate**1&moc=200&v=11 at 200% overclock, one Mk 1 belt is 12000/min instead of 60/min

This fixes a copy-paste mistake from https://github.com/factoriolab/factoriolab/pull/1679