### PR TITLE
fix: prevent division by zero for rocketCapacity in calculateBelts

### DIFF
--- a/src/app/services/rate.service.ts
+++ b/src/app/services/rate.service.ts
@@ -238,7 +238,7 @@ export class RateService {
 
       if (step.items != null) {
         const item = data.itemEntities[step.itemId];
-        if (item.rocketCapacity)
+        if (item.rocketCapacity?.nonzero())
           step.rockets = step.items.div(item.rocketCapacity);
       }
     }


### PR DESCRIPTION
- Check for zero before dividing rocket capacity

Intended to fix #1747
