### PR TITLE
Makes some code branches more resiliant by handling (ignoring) values of unknown

### DIFF
--- a/scripts/factorio-build.ts
+++ b/scripts/factorio-build.ts
@@ -913,14 +913,14 @@ async function processMod(): Promise<void> {
     recipeResultsMap[recipe.name] = products;
   }
 
-  const itemsUsedProtos = Array.from(itemsUsed.values()).map(
-    (key) => itemMap[key],
-  );
+  const itemsUsedProtos = Array.from(itemsUsed.values())
+    .map((key) => itemMap[key])
+    .filter((k) => k !== undefined);
 
   // Exclude any entities that are placed by the added items
   const placedEntities = new Set<string>();
   for (const proto of itemsUsedProtos) {
-    if (!isFluidPrototype(proto) && proto.place_result != null)
+    if (!isFluidPrototype(proto) && proto?.place_result != null)
       placedEntities.add(proto.place_result);
   }
 
@@ -1134,7 +1134,7 @@ async function processMod(): Promise<void> {
       if (proto.weight != null) {
         itemWeight[proto.name] = proto.weight;
       } else if (
-        proto.flags?.some((f) => f === 'only-in-cursor' || f === 'spawnable')
+        proto.flags?.some?.((f) => f === 'only-in-cursor' || f === 'spawnable')
       ) {
         itemWeight[proto.name] = 0;
       }

--- a/scripts/factorio.models.ts
+++ b/scripts/factorio.models.ts
@@ -2968,7 +2968,7 @@ export type FluidPrototype = _FluidPrototype &
   Omit<Prototype, keyof _FluidPrototype>;
 
 export function isFluidPrototype(value: unknown): value is FluidPrototype {
-  return (value as { type: string }).type === 'fluid';
+  return value !== undefined && (value as { type: string }).type === 'fluid';
 }
 
 /** Used for example for the handheld flamethrower. */

--- a/scripts/helpers/data.helpers.ts
+++ b/scripts/helpers/data.helpers.ts
@@ -127,7 +127,7 @@ export function getAllowedLocations(
   locations: AnyLocationPrototype[],
   defaults: Record<string, number>,
 ): Optional<AnyLocationPrototype[]> {
-  if (surface_conditions == null) return undefined;
+  if (!surface_conditions?.every) return undefined;
 
   const matches = locations.filter((l) => {
     return surface_conditions.every((c) => {

--- a/src/app/components/tooltip/tooltip.component.html
+++ b/src/app/components/tooltip/tooltip.component.html
@@ -380,7 +380,7 @@
       <div class="mt-1">{{ 'data.producers' | translate }}</div>
       <div>
         @for (producer of recipe.producers; track producer) {
-          @if (data().itemEntities[producer].quality == null) {
+          @if (data().itemEntities[producer]?.quality == null) {
             <i [class]="producer | iconSmClass"></i>
           }
         }

--- a/src/app/models/enum/quality.ts
+++ b/src/app/models/enum/quality.ts
@@ -52,6 +52,6 @@ export function recipeHasQuality(
     (!flags.has('technology') || Object.keys(recipe.in).length > 0) &&
     !flags.has('burn') &&
     !flags.has('grow') &&
-    Object.keys(recipe.in).some((k) => itemData[k].stack)
+    Object.keys(recipe.in).some((k) => itemData[k]?.stack)
   );
 }


### PR DESCRIPTION
This can happen if some mods (e.g. Planet Rubia) are a bit lazy with their prototype definitions. Factorio can handle this but the `factorio-build` script had its problems.