### PR TITLE
fix: issue with icon sizes for non-standard font-size

### DIFF
--- a/src/components/icon/icon.html
+++ b/src/components/icon/icon.html
@@ -1,6 +1,6 @@
 @if (icon(); as icon) {
   <span
-    class="size-16 absolute origin-top-left"
+    class="icon-sprite absolute origin-top-left"
     [class.scale-50]="!full()"
     [style.background-image]="icon.image"
     [style.background-position]="icon.position"

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -79,6 +79,12 @@
     }
   }
 
+  .icon-sprite {
+    width: 64px;
+    height: 64px;
+    zoom: tan(atan2(1rem, 16px));
+  }
+
   fa-icon {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Fix for #1884 

Change icon size to px instead of rem and add a zoom function to calculate the ratio for rem/px so that it scales proportionally