### PR TITLE
feat: Add default inserter setting

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -445,6 +445,8 @@
     "defaultCargoWagonTooltip": "Select the default cargo wagon to be used by all items",
     "defaultFluidWagon": "Default fluid wagon",
     "defaultFluidWagonTooltip": "Select the default fluid wagon to be used by all fluids",
+    "defaultInserter": "Default inserter",
+    "defaultInserterTooltip": "Select the default inserter to be used by all recipes",
     "defaultPipe": "Default pipe",
     "defaultPipeTooltip": "Select the default pipe to be used by all fluids",
     "defaultStack": "Default stack size",

--- a/src/app/main/settings/settings.html
+++ b/src/app/main/settings/settings.html
@@ -581,6 +581,24 @@
         </lab-form-field>
       }
 
+      @if (options().inserters.length > 1) {
+        <lab-form-field label="settings.defaultInserter">
+          <lab-select
+            [options]="options().insertersAuto"
+            labTooltip="settings.defaultInserterTooltip"
+            labTooltipPosition="adjacent"
+            [ngModel]="settings().inserterId"
+            (ngModelChange)="
+              settingsStore.updateField(
+                'inserterId',
+                $event,
+                settings().defaultInserterId
+              )
+            "
+          ></lab-select>
+        </lab-form-field>
+      }
+
       @if (data().flags.has('flowRate')) {
         <lab-form-field label="settings.pipeFlowRate">
           <div class="flex items-stretch">

--- a/src/components/steps/detail-row/detail-row.spec.ts
+++ b/src/components/steps/detail-row/detail-row.spec.ts
@@ -72,5 +72,14 @@ describe('DetailRow', () => {
       await TestBed.inject(ApplicationRef).whenStable();
       expect(component['inserterId']()).toEqual(ItemId.BulkInserter);
     });
+
+    it('should use the inserterId from the settings', async () => {
+      component['settingsStore'].apply({ inserterId: ItemId.FastInserter });
+      setInputs(fixture, {
+        value: { itemId: ItemId.ElectronicCircuit, items: rational(3600n) },
+      });
+      await TestBed.inject(ApplicationRef).whenStable();
+      expect(component['inserterId']()).toEqual(ItemId.FastInserter);
+    });
   });
 });

--- a/src/components/steps/detail-row/detail-row.ts
+++ b/src/components/steps/detail-row/detail-row.ts
@@ -69,6 +69,7 @@ export class DetailRow {
     const data = this.data();
     const value = this.value();
     const items = this.items();
+    const settings = this.settingsStore.state();
     /**
      * Verify data includes inserters, step includes items, and item is not a
      * fluid
@@ -80,6 +81,12 @@ export class DetailRow {
       data.itemRecord[value.itemId].stack == null
     )
       return undefined;
+
+    if (
+      settings.inserterId !== undefined &&
+      settings.inserterId !== '' /* Optimal inserter, computed below */
+    )
+      return settings.inserterId;
 
     const inserterSpeed = this.recipesStore.inserterSpeed();
     let inserterId: string | undefined;

--- a/src/data/schema/defaults.ts
+++ b/src/data/schema/defaults.ts
@@ -9,6 +9,7 @@ export interface HardCodedPresetsJson {
   fuelRank?: string[];
   cargoWagon?: string;
   fluidWagon?: string;
+  inserter?: string;
   excludedRecipes?: string[];
   minMachineRank?: string[];
   maxMachineRank?: string[];
@@ -27,6 +28,7 @@ export interface CustomPresetsJson {
   fuelRank?: string[];
   cargoWagon?: string;
   fluidWagon?: string;
+  inserter?: string;
   excludedRecipes?: string[];
   machineRank?: string[];
   moduleRank?: string[];
@@ -49,6 +51,7 @@ export interface PresetJson {
   fuelRank?: string[];
   cargoWagon?: string;
   fluidWagon?: string;
+  inserter?: string;
   excludedRecipes?: string[];
   machineRank?: string[];
   moduleRank?: string[];

--- a/src/state/items/item-settings.ts
+++ b/src/state/items/item-settings.ts
@@ -6,4 +6,5 @@ export interface ItemSettings extends ItemState {
   defaultBeltId: string;
   defaultStack: Rational;
   defaultWagonId: string;
+  defaultInserterId: string;
 }

--- a/src/state/items/item-state.ts
+++ b/src/state/items/item-state.ts
@@ -4,5 +4,6 @@ export interface ItemState {
   beltId?: string;
   stack?: Rational;
   wagonId?: string;
+  inserterId?: string;
   excludeRockets?: boolean;
 }

--- a/src/state/items/items-store.ts
+++ b/src/state/items/items-store.ts
@@ -51,9 +51,11 @@ export class ItemsStore extends RecordStore<ItemState> {
       );
       const defaultStack = this.defaultStack(item, settings);
       const defaultWagonId = this.defaultWagon(item, settings);
+      const defaultInserterId = this.defaultInserter(item, settings);
       const beltId = coalesce(s?.beltId, defaultBeltId);
       const stack = coalesce(s?.stack, defaultStack);
       const wagonId = coalesce(s?.wagonId, defaultWagonId);
+      const inserterId = coalesce(s?.inserterId, defaultInserterId);
       const excludeRockets = s?.excludeRockets;
 
       value[item.id] = {
@@ -63,6 +65,8 @@ export class ItemsStore extends RecordStore<ItemState> {
         defaultStack,
         wagonId,
         defaultWagonId,
+        inserterId,
+        defaultInserterId,
         excludeRockets,
       };
     }
@@ -91,5 +95,9 @@ export class ItemsStore extends RecordStore<ItemState> {
       item.stack ? settings.cargoWagonId : settings.fluidWagonId,
       '',
     );
+  }
+
+  private defaultInserter(item: Item, settings: Settings): string {
+    return coalesce(settings.inserterId, '');
   }
 }

--- a/src/state/settings/defaults.ts
+++ b/src/state/settings/defaults.ts
@@ -10,6 +10,7 @@ export interface Defaults {
   fuelRankIds: string[];
   cargoWagonId?: string;
   fluidWagonId?: string;
+  inserterId?: string;
   excludedRecipeIds: string[];
   machineRankIds: string[];
   moduleRankIds: string[];

--- a/src/state/settings/options.ts
+++ b/src/state/settings/options.ts
@@ -8,6 +8,7 @@ export interface Options {
   cargoWagons: Option[];
   fluidWagons: Option[];
   inserters: Option[];
+  insertersAuto: Option[];
   fuels: Option[];
   modules: Option[];
   proliferatorModules: Option[];

--- a/src/state/settings/settings-state.ts
+++ b/src/state/settings/settings-state.ts
@@ -18,6 +18,7 @@ export interface SettingsState {
   pipeId?: string;
   cargoWagonId?: string;
   fluidWagonId?: string;
+  inserterId?: string;
   flowRate: Rational;
   stack?: Rational;
   excludedRecipeIds?: Set<string>;

--- a/src/state/settings/settings-store.ts
+++ b/src/state/settings/settings-store.ts
@@ -263,6 +263,15 @@ export class SettingsStore extends Store<SettingsState> {
         firstAsEmpty: true,
       }),
       inserters: itemOptions(data.inserterIds, { tooltipType: 'inserter' }),
+      insertersAuto: itemOptions(data.inserterIds, {
+        tooltipType: 'inserter',
+        emptyOption: {
+          label: 'Optimal inserter',
+          value: '',
+          icon: data.inserterIds[1], // Basic inserter
+          iconClass: 'opacity-40',
+        },
+      }),
       fuels: itemOptions(data.fuelIds, {
         exclude: data.itemQIds,
         tooltipType: 'fuel',
@@ -388,6 +397,7 @@ export class SettingsStore extends Store<SettingsState> {
         pipeId: coalesce(p.pipe, m.pipe),
         cargoWagonId: coalesce(p.cargoWagon, m.cargoWagon),
         fluidWagonId: coalesce(p.fluidWagon, m.fluidWagon),
+        inserterId: coalesce(p.inserter, m.inserter),
         excludedRecipeIds: coalesce(excludedRecipe, []),
         machineRankIds: coalesce(machineRank, []),
         fuelRankIds: coalesce(fuelRank, []),
@@ -447,6 +457,7 @@ export class SettingsStore extends Store<SettingsState> {
       pipeId: preset === Preset.Minimum ? m.minPipe : m.maxPipe,
       cargoWagonId: m.cargoWagon,
       fluidWagonId: m.fluidWagon,
+      inserterId: m.inserter,
       excludedRecipeIds: coalesce(m.excludedRecipes, []),
       machineRankIds: coalesce(machineRankIds, []),
       fuelRankIds: coalesce(m.fuelRank, []),
@@ -1035,6 +1046,8 @@ export class SettingsStore extends Store<SettingsState> {
     const cargoWagonId = pickItemId(state.cargoWagonId, defaultCargoWagonId);
     const defaultFluidWagonId = coalesce(defaults?.fluidWagonId, '');
     const fluidWagonId = pickItemId(state.fluidWagonId, defaultFluidWagonId);
+    const defaultInserterId = coalesce(defaults?.inserterId, '');
+    const inserterId = pickItemId(state.inserterId, defaultInserterId);
     const defaultMachineRankIds = coalesce(defaults?.machineRankIds, []);
     const machineRankIds = pickItemIds(
       state.machineRankIds,
@@ -1087,6 +1100,8 @@ export class SettingsStore extends Store<SettingsState> {
       defaultCargoWagonId,
       fluidWagonId,
       defaultFluidWagonId,
+      inserterId,
+      defaultInserterId,
       excludedRecipeIds,
       defaultExcludedRecipeIds,
       recipeBonus,

--- a/src/state/settings/settings.ts
+++ b/src/state/settings/settings.ts
@@ -8,6 +8,7 @@ export interface Settings extends SettingsState {
   defaultPipeId: string;
   defaultCargoWagonId: string;
   defaultFluidWagonId: string;
+  defaultInserterId: string;
   stack: Rational;
   excludedRecipeIds: Set<string>;
   defaultExcludedRecipeIds: Set<string>;


### PR DESCRIPTION
This PR adds a setting to set the inserter to be used in the machine detail. The default is the same as before; it will compute the optimal inserter to use.

Alternatively, we could change it to a ranked selection so that the user can precisely choose their preferred inserters, but it feels more overwhelming and less practical. Personally, I only use a handful of inserters at most at any point in the game.