### PR TITLE
fix: No default productivity bonus from research

### DIFF
--- a/src/state/settings/settings-store.ts
+++ b/src/state/settings/settings-store.ts
@@ -955,12 +955,6 @@ export class SettingsStore extends Store<SettingsState> {
         });
       }
 
-      if (tech.miningProductivity) {
-        miningBonus = miningBonus.add(
-          tech.miningProductivity.mul(rational(100n)),
-        );
-      }
-
       if (tech.qualityUnlock) {
         tech.qualityUnlock.forEach((q) => {
           const unlock = data.qualityRecord[q];
@@ -971,12 +965,6 @@ export class SettingsStore extends Store<SettingsState> {
       if (tech.researchSpeed) {
         researchBonus = researchBonus.add(
           tech.researchSpeed.mul(rational(100n)),
-        );
-      }
-
-      if (tech.researchProductivity) {
-        researchProductivity = researchProductivity.add(
-          tech.researchProductivity.mul(rational(100n)),
         );
       }
     });
@@ -1002,18 +990,7 @@ export class SettingsStore extends Store<SettingsState> {
           (r.quality == null || r.quality.level <= coalesce(quality?.level, 0)),
       );
 
-    // Recipe productivity bonuses unlocked by technology
-    const recipeBonus = Array.from(researchedTechnologyIds).reduce<
-      Partial<Record<string, Rational>>
-    >((result, b) => {
-      const tech = data.technologyRecord[b];
-      tech.recipeProductivity?.forEach((eff) => {
-        result[eff.id] ??= rational.zero;
-        result[eff.id] = result[eff.id]?.add(eff.value.mul(rational(100n)));
-      });
-      return result;
-    }, {});
-
+    const recipeBonus: Partial<Record<string, Rational>> = {};
     if (defaults?.recipeProductivity) {
       for (const [recipeId, bonus] of toRecordEntries(
         defaults?.recipeProductivity,


### PR DESCRIPTION
This changes:

* Recipe producivity bonuses
* Research productivity bonus
* Mining productivity bonus

… to no longer be affected by researched technologies and default to 0%.

For Factorio, Factoriolab settings include a set of researched technologies. The technologies relevant here are repeatable, each level gives an additional +10% bonus. But Factoriolab has no notion of research level, so having them present in the set means level 1. The default set is "all".

Before this PR, this makes some recipes have a default 10% productivity bonus, which is arguably unexpected. For example:

https://factoriolab.github.io/2x1/list?o=plastic-bar**3&odr=0&loc=B&v=11

There are separate settings and UI to set those bonuses directly.

This PR removes the effect of technologies on those bonuses, leaving only the dedicated settings and UI.

An alternative would be to replace the set of researched technology with a map that associates an integer researched level to each technology, and remove the separate settings and UI for setting bonuses directly. But I don’t know how to make UI for a map like that.